### PR TITLE
MAINT: exclude jupyter-book tests until after initial release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Run pytest
       run: |
-        pytest --durations=10 --cov=sphinx_jupyterbook_latex --cov-report=xml --cov-report=term-missing
+        pytest --durations=10 --cov=sphinx_jupyterbook_latex --cov-report=xml --cov-report=term-missing --ignore=tests/test_jupyter_book.py
         coverage xml
 
     - name: Upload to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         name: sphinx-jupyterbook-latex-pytest-py3.7
         flags: pytests
         file: ./coverage.xml
-        fail_ci_if_error: true
+        fail_ci_if_error: false
 
   tests:
 


### PR DESCRIPTION
This PR excludes

`tests/test_jupyter_book.py`

until after the initial release as `jupyter-book` needs to be updated to use `sphinx-jupyterbook-latex>=0.4.0` for these tests to work. 

It also switches off the upload to `codecov` until a fix is identified with the github action upload