### PR TITLE
👌 IMPROVE: Added hypersetup to allow greek in titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         name: sphinx-jupyterbook-latex-pytest-py3.7
         flags: pytests
         file: ./coverage.xml
-        fail_ci_if_error: false
+        fail_ci_if_error: true
 
   tests:
 

--- a/sphinx_jupyterbook_latex/events.py
+++ b/sphinx_jupyterbook_latex/events.py
@@ -44,6 +44,10 @@ def override_latex_config(app: Sphinx, config: Config) -> None:
         \usepackage{unicode-math}
         % fixing title of the toc
         \addto\captionsenglish{\renewcommand{\contentsname}{Contents}}
+        \hypersetup{
+            pdfencoding=auto,
+            psdextra
+        }
         """
     )
 

--- a/sphinx_jupyterbook_latex/events.py
+++ b/sphinx_jupyterbook_latex/events.py
@@ -40,6 +40,7 @@ def override_latex_config(app: Sphinx, config: Config) -> None:
     latex_elements["preamble"] = (
         config_preamble
         + r"""
+        % Start of preamble defined in sphinx-jupyterbook-latex %
          \usepackage[Latin,Greek]{ucharclasses}
         \usepackage{unicode-math}
         % fixing title of the toc
@@ -48,6 +49,7 @@ def override_latex_config(app: Sphinx, config: Config) -> None:
             pdfencoding=auto,
             psdextra
         }
+        % End of preamble defined in sphinx-jupyterbook-latex %
         """
     )
 


### PR DESCRIPTION
The basic setup for hyperref package added by sphinx does not allow greek characters in titles of doc.

For example:
```
## Equilibrium with $\theta_t$ stochastic but observed at $t$
```

would throw an error with something like:

```
! Improper alphabetic constant.
<to be read again> 
                   \mittheta 
l.29573 ...signal on \protect\(\theta_t\protect\)}
```

The following PR allows greek characters. 