### PR TITLE
✨ NEW: Formatting of output code cells

### DIFF
--- a/sphinx_jupyterbook_latex/__init__.py
+++ b/sphinx_jupyterbook_latex/__init__.py
@@ -14,8 +14,9 @@ def setup(app: "Sphinx") -> None:
     """The sphinx entry-point for the extension."""
 
     from .events import override_latex_config, setup_latex_transforms
-    from .nodes import HiddenCellNode, RootHeader
+    from .nodes import CellOutput, HiddenCellNode, RootHeader
     from .transforms import (
+        CodeBlockTransforms,
         LatexRootDocTransforms,
         LatexToctreeNodeInterpret,
         ListTableOfContents,
@@ -30,10 +31,12 @@ def setup(app: "Sphinx") -> None:
 
     HiddenCellNode.add_node(app)
     RootHeader.add_node(app)
+    CellOutput.add_node(app)
 
     app.add_transform(LatexRootDocTransforms)
     app.add_transform(LatexToctreeNodeInterpret)
     app.add_post_transform(ListTableOfContents)
+    app.add_post_transform(CodeBlockTransforms)
 
     app.connect("config-inited", override_latex_config)
     app.connect("builder-inited", setup_latex_transforms)

--- a/sphinx_jupyterbook_latex/__init__.py
+++ b/sphinx_jupyterbook_latex/__init__.py
@@ -14,7 +14,7 @@ def setup(app: "Sphinx") -> None:
     """The sphinx entry-point for the extension."""
 
     from .events import override_latex_config, setup_latex_transforms
-    from .nodes import CellOutput, HiddenCellNode, RootHeader
+    from .nodes import CellInput, CellOutput, HiddenCellNode, RootHeader
     from .transforms import (
         CodeBlockTransforms,
         LatexRootDocTransforms,
@@ -32,6 +32,7 @@ def setup(app: "Sphinx") -> None:
     HiddenCellNode.add_node(app)
     RootHeader.add_node(app)
     CellOutput.add_node(app)
+    CellInput.add_node(app)
 
     app.add_transform(LatexRootDocTransforms)
     app.add_transform(LatexToctreeNodeInterpret)

--- a/sphinx_jupyterbook_latex/nodes.py
+++ b/sphinx_jupyterbook_latex/nodes.py
@@ -4,6 +4,8 @@ from typing import Any, cast
 from docutils import nodes
 from sphinx.application import Sphinx
 
+CR = "\n"
+
 
 def sphinx_encode(string: str) -> str:
     """Replace tilde, hyphen and single quotes with their LaTeX commands."""
@@ -96,3 +98,27 @@ def depart_RootHeader(self, node: RootHeader) -> None:
     if index:
         self.body[index] = size + node["header_text"]
     # else throw an error
+
+
+class CellOutput(nodes.Element):
+    """A node for code cell outputs designed for latex."""
+
+    def __init__(self, rawsource="", *children, **attributes):
+        super().__init__("", **attributes)
+
+    @classmethod
+    def add_node(cls, app: Sphinx) -> None:
+        add_node = cast(Any, app.add_node)  # has the wrong typing for sphinx<4
+        add_node(
+            cls,
+            override=True,
+            latex=(visit_CellOutput, depart_CellOutput),
+        )
+
+
+def visit_CellOutput(self, node) -> None:
+    self.body.append("\\begin{sphinxVerbatimOutput}" + CR)
+
+
+def depart_CellOutput(self, node) -> None:
+    self.body.append("\\end{sphinxVerbatimOutput}" + CR)

--- a/sphinx_jupyterbook_latex/nodes.py
+++ b/sphinx_jupyterbook_latex/nodes.py
@@ -122,3 +122,27 @@ def visit_CellOutput(self, node) -> None:
 
 def depart_CellOutput(self, node) -> None:
     self.body.append("\\end{sphinxVerbatimOutput}" + CR)
+
+
+class CellInput(nodes.Element):
+    """A node for code cell inputs designed for latex."""
+
+    def __init__(self, rawsource="", *children, **attributes):
+        super().__init__("", **attributes)
+
+    @classmethod
+    def add_node(cls, app: Sphinx) -> None:
+        add_node = cast(Any, app.add_node)  # has the wrong typing for sphinx<4
+        add_node(
+            cls,
+            override=True,
+            latex=(visit_CellInput, depart_CellInput),
+        )
+
+
+def visit_CellInput(self, node) -> None:
+    self.body.append("\\begin{sphinxVerbatimInput}" + CR)
+
+
+def depart_CellInput(self, node) -> None:
+    self.body.append("\\end{sphinxVerbatimInput}" + CR)

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -51,10 +51,10 @@
 \DeclareMathOperator*{\gt}{>}
 
 \definecolor{VerbatimOutputColor}{RGB}{232,232,224}
+\definecolor{VerbatimBorderColor}{RGB}{20,20,20}
 
 \makeatletter
 \newenvironment{sphinxVerbatimOutput}
-  {\spx@opt@verbatimwithframefalse
-  \def\spx@verbatimfcolorbox{\spx@fcolorbox{white}{VerbatimOutputColor}}}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{VerbatimBorderColor}{VerbatimOutputColor}}}
   {\def\spx@verbatimfcolorbox{\spx@fcolorbox{VerbatimBorderColor}{VerbatimColor}}}
 \makeatother

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -57,8 +57,8 @@
 \definecolor{CodeBlockOutputBorderColor}{RGB}{247,247,247}
 \definecolor{CodeBlockOutputColor}{RGB}{252,252,252}
 
-%% this environment at present does not work well with sphinxVerbatim
-%% TODO: edit this to make a left margin
+% This environment at present does not work well with sphinxVerbatim
+% TODO: edit this to make a left margin
 \newenvironment{leftbarin}
 {%
     \def\FrameCommand
@@ -71,12 +71,14 @@
 }
 {\endMakeFramed}
 
+% Env which wraps code cell inputs
 \makeatletter
 \newenvironment{sphinxVerbatimInput}
   {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockInputBorderColor}{CodeBlockInputColor}}\begin{adjustwidth}{6pt}{}}
   {\end{adjustwidth}}
 \makeatother
 
+% Env which wraps code cell outputs
 \makeatletter
 \newenvironment{sphinxVerbatimOutput}
   {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockOutputBorderColor}{CodeBlockOutputColor}} \begin{adjustwidth}{20pt}{}}

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -20,6 +20,7 @@
 
 \setlength{\textwidth}{17.5cm}
 \setlength{\textheight}{22cm}
+\setlength{\fboxsep}{10pt}
 
 \newcommand{\RR}{\mathbbm R}
 \newcommand{\NN}{\mathbbm N}

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -20,7 +20,7 @@
 
 \setlength{\textwidth}{17.5cm}
 \setlength{\textheight}{22cm}
-\setlength{\fboxsep}{10pt}
+\setlength{\fboxsep}{6pt}
 
 \newcommand{\RR}{\mathbbm R}
 \newcommand{\NN}{\mathbbm N}
@@ -58,6 +58,7 @@
 \definecolor{CodeBlockOutputColor}{RGB}{252,252,252}
 
 %% this environment at present does not work well with sphinxVerbatim
+%% TODO: edit this to make a left margin
 \newenvironment{leftbarin}
 {%
     \def\FrameCommand
@@ -72,12 +73,12 @@
 
 \makeatletter
 \newenvironment{sphinxVerbatimInput}
-  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockInputBorderColor}{CodeBlockInputColor}} \begin{adjustwidth}{10pt}{}}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockInputBorderColor}{CodeBlockInputColor}}\begin{adjustwidth}{6pt}{}}
   {\end{adjustwidth}}
 \makeatother
 
 \makeatletter
 \newenvironment{sphinxVerbatimOutput}
-  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockOutputBorderColor}{CodeBlockOutputColor}} \begin{adjustwidth}{30pt}{}}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockOutputBorderColor}{CodeBlockOutputColor}} \begin{adjustwidth}{20pt}{}}
   {\end{adjustwidth}}
 \makeatother

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -20,7 +20,7 @@
 
 \setlength{\textwidth}{17.5cm}
 \setlength{\textheight}{22cm}
-\setlength{\fboxsep}{6pt}
+\setlength{\fboxsep}{5pt}
 
 \newcommand{\RR}{\mathbbm R}
 \newcommand{\NN}{\mathbbm N}
@@ -74,7 +74,7 @@
 % Env which wraps code cell inputs
 \makeatletter
 \newenvironment{sphinxVerbatimInput}
-  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockInputBorderColor}{CodeBlockInputColor}}\begin{adjustwidth}{6pt}{}}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockInputBorderColor}{CodeBlockInputColor}}\begin{adjustwidth}{5pt}{}}
   {\end{adjustwidth}}
 \makeatother
 

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -49,3 +49,12 @@
 \DeclareMathOperator*{\argmin}{arg\,min}
 \DeclareMathOperator*{\argmax}{arg\,max}
 \DeclareMathOperator*{\gt}{>}
+
+\definecolor{VerbatimOutputColor}{RGB}{232,232,224}
+
+\makeatletter
+\newenvironment{sphinxVerbatimOutput}
+  {\spx@opt@verbatimwithframefalse
+  \def\spx@verbatimfcolorbox{\spx@fcolorbox{white}{VerbatimOutputColor}}}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{VerbatimBorderColor}{VerbatimColor}}}
+\makeatother

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -16,7 +16,7 @@
 \RequirePackage{bbm}
 \def\sphinxdocclass{report}
 \LoadClass{sphinxmanual}
-
+\RequirePackage[strict]{changepage}
 
 \setlength{\textwidth}{17.5cm}
 \setlength{\textheight}{22cm}
@@ -50,11 +50,33 @@
 \DeclareMathOperator*{\argmax}{arg\,max}
 \DeclareMathOperator*{\gt}{>}
 
-\definecolor{VerbatimOutputColor}{RGB}{232,232,224}
-\definecolor{VerbatimBorderColor}{RGB}{20,20,20}
+\definecolor{codeBlockInputLeftFrame}{RGB}{0,45,74}
+\definecolor{CodeBlockInputBorderColor}{RGB}{204,204,204}
+\definecolor{CodeBlockInputColor}{RGB}{247,247,247}
+\definecolor{CodeBlockOutputBorderColor}{RGB}{247,247,247}
+\definecolor{CodeBlockOutputColor}{RGB}{252,252,252}
+
+%% this environment at present does not work well with sphinxVerbatim
+\newenvironment{leftbarin}
+{%
+    \def\FrameCommand
+    {%
+        {\color{codeBlockInputLeftFrame}\vrule width 3pt}%
+        \hspace{0pt}%must no space.
+        \fboxsep=\FrameSep\colorbox{CodeBlockInputColor}%
+    }%
+    \MakeFramed{\advance\hsize-\width\@totalleftmargin\z@\linewidth\hsize\@setminipage}%
+}
+{\endMakeFramed}
+
+\makeatletter
+\newenvironment{sphinxVerbatimInput}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockInputBorderColor}{CodeBlockInputColor}} \begin{adjustwidth}{10pt}{}}
+  {\end{adjustwidth}}
+\makeatother
 
 \makeatletter
 \newenvironment{sphinxVerbatimOutput}
-  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{VerbatimBorderColor}{VerbatimOutputColor}}}
-  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{VerbatimBorderColor}{VerbatimColor}}}
+  {\def\spx@verbatimfcolorbox{\spx@fcolorbox{CodeBlockOutputBorderColor}{CodeBlockOutputColor}} \begin{adjustwidth}{30pt}{}}
+  {\end{adjustwidth}}
 \makeatother

--- a/sphinx_jupyterbook_latex/transforms.py
+++ b/sphinx_jupyterbook_latex/transforms.py
@@ -12,7 +12,7 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import logging
 from sphinx.util.nodes import clean_astext
 
-from .nodes import CellOutput, HiddenCellNode, RootHeader
+from .nodes import CellInput, CellOutput, HiddenCellNode, RootHeader
 
 logger = logging.getLogger(__name__)
 
@@ -428,9 +428,14 @@ class CodeBlockTransforms(SphinxPostTransform):
 
     def apply(self):
         if isinstance(self.env.app.builder, builders.latex.LaTeXBuilder):
-            from myst_nb.nodes import CellOutputNode
+            from myst_nb.nodes import CellInputNode, CellOutputNode
 
             for node in self.document.traverse(CellOutputNode):
                 celloutput = CellOutput()
                 celloutput.append(node.deepcopy())
                 node.replace_self(celloutput)
+
+            for node in self.document.traverse(CellInputNode):
+                cellinput = CellInput()
+                cellinput.append(node.deepcopy())
+                node.replace_self(cellinput)

--- a/sphinx_jupyterbook_latex/transforms.py
+++ b/sphinx_jupyterbook_latex/transforms.py
@@ -423,12 +423,13 @@ class ListTableOfContents(SphinxPostTransform):
 
 
 class CodeBlockTransforms(SphinxPostTransform):
-    """Wrapping myst_nb code cell nodes with nodes of this extension."""
+    """Handling any post transforms needed for code cells."""
 
     default_priority = 999
 
     def apply(self):
         if isinstance(self.env.app.builder, builders.latex.LaTeXBuilder):
+            """Wrapping myst_nb code cell nodes with nodes of this extension. """
             from myst_nb.nodes import CellInputNode, CellOutputNode
 
             for node in self.document.traverse(CellOutputNode):

--- a/sphinx_jupyterbook_latex/transforms.py
+++ b/sphinx_jupyterbook_latex/transforms.py
@@ -431,6 +431,6 @@ class CodeBlockTransforms(SphinxPostTransform):
             from myst_nb.nodes import CellOutputNode
 
             for node in self.document.traverse(CellOutputNode):
-                celloutputnode = CellOutput()
-                celloutputnode.append(node.deepcopy())
-                node.replace_self(celloutputnode)
+                celloutput = CellOutput()
+                celloutput.append(node.deepcopy())
+                node.replace_self(celloutput)

--- a/sphinx_jupyterbook_latex/transforms.py
+++ b/sphinx_jupyterbook_latex/transforms.py
@@ -12,7 +12,7 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import logging
 from sphinx.util.nodes import clean_astext
 
-from .nodes import HiddenCellNode, RootHeader
+from .nodes import CellOutput, HiddenCellNode, RootHeader
 
 logger = logging.getLogger(__name__)
 
@@ -420,3 +420,17 @@ class ListTableOfContents(SphinxPostTransform):
                         [tocnode], nodes_to_visit, inserted_nodes
                     )
                     tocnode.replace_self(listnode)
+
+
+class CodeBlockTransforms(SphinxPostTransform):
+
+    default_priority = 999
+
+    def apply(self):
+        if isinstance(self.env.app.builder, builders.latex.LaTeXBuilder):
+            from myst_nb.nodes import CellOutputNode
+
+            for node in self.document.traverse(CellOutputNode):
+                celloutputnode = CellOutput()
+                celloutputnode.append(node.deepcopy())
+                node.replace_self(celloutputnode)

--- a/sphinx_jupyterbook_latex/transforms.py
+++ b/sphinx_jupyterbook_latex/transforms.py
@@ -423,6 +423,7 @@ class ListTableOfContents(SphinxPostTransform):
 
 
 class CodeBlockTransforms(SphinxPostTransform):
+    """Wrapping myst_nb code cell nodes with nodes of this extension."""
 
     default_priority = 999
 

--- a/tests/test_transforms/test_hide_cell.resolved.xml
+++ b/tests/test_transforms/test_hide_cell.resolved.xml
@@ -5,9 +5,11 @@
         <paragraph>
             Code Cells with tags in it:
         <HiddenCellNode classes="cell tag_hide-cell">
-            <CellInputNode classes="cell_input">
-                <literal_block language="ipython3" linenos="False" xml:space="preserve">
-                    print("Here is some code to execute")
-            <CellOutputNode classes="cell_output">
-                <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
-                    Here is some code to execute
+            <CellInput classes="cell_input">
+                <CellInputNode classes="cell_input">
+                    <literal_block language="ipython3" linenos="False" xml:space="preserve">
+                        print("Here is some code to execute")
+            <CellOutput classes="cell_output">
+                <CellOutputNode classes="cell_output">
+                    <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
+                        Here is some code to execute

--- a/tests/test_transforms/test_hide_input.resolved.xml
+++ b/tests/test_transforms/test_hide_input.resolved.xml
@@ -8,6 +8,7 @@
             <HiddenCellNode classes="cell_input">
                 <literal_block language="ipython3" linenos="False" xml:space="preserve">
                     print("Here is some code to execute")
-            <CellOutputNode classes="cell_output">
-                <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
-                    Here is some code to execute
+            <CellOutput classes="cell_output">
+                <CellOutputNode classes="cell_output">
+                    <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
+                        Here is some code to execute

--- a/tests/test_transforms/test_hide_output.resolved.xml
+++ b/tests/test_transforms/test_hide_output.resolved.xml
@@ -5,9 +5,10 @@
         <paragraph>
             Below is a cell with hide-output tag:
         <CellNode cell_type="code" classes="cell tag_hide-output">
-            <CellInputNode classes="cell_input">
-                <literal_block language="ipython3" linenos="False" xml:space="preserve">
-                    print("Here is some code to execute")
+            <CellInput classes="cell_input">
+                <CellInputNode classes="cell_input">
+                    <literal_block language="ipython3" linenos="False" xml:space="preserve">
+                        print("Here is some code to execute")
             <HiddenCellNode classes="cell_output">
                 <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
                     Here is some code to execute


### PR DESCRIPTION
@mmcky here I have made a new `CellOutput` node instead of overriding `visit_literal_block` which I had suggested as inevitable and we had agreed upon in our chat yesterday. 

The present approach just wraps around `sphinxVerbatim` and provides styling. This is less invasive and prevents fiddling with existing sphinx nodes. 

Will change the node name to something more specific, showing this as a proof of concept in the first iteration.

Before image taken from https://github.com/executablebooks/sphinx-jupyterbook-latex/issues/10
(Left: Before, Right: After)
<p align="center">
<img width="45%" style="max-width:45%" alt="101757324-22e50900-3b2b-11eb-974b-4b4090a89c09" src="https://user-images.githubusercontent.com/6542997/139175453-c720b4cf-042b-4419-8185-3b9f0147968e.png"> 
<img width="45%"  style="max-width:45%" alt="Screen Shot 2021-10-28 at 1 26 50 pm" src="https://user-images.githubusercontent.com/6542997/139175577-ec2fdb17-0f0a-4de5-8561-5d58d66cd0bc.png">
</p>

2nd option:
<p align="center">
<img width="45%" style="max-width:45%" alt="101757324-22e50900-3b2b-11eb-974b-4b4090a89c09" src="https://user-images.githubusercontent.com/6542997/139175453-c720b4cf-042b-4419-8185-3b9f0147968e.png"> 
<img width="45%" style="max-width:45%" alt="Screen Shot 2021-10-29 at 5 27 55 pm" src="https://user-images.githubusercontent.com/6542997/139751563-9f0cb226-eefa-4064-8261-12fdc972231c.png">
</p>

3rd option:
<p align="center">
<img width="45%" style="max-width:45%" alt="101757324-22e50900-3b2b-11eb-974b-4b4090a89c09" src="https://user-images.githubusercontent.com/6542997/139175453-c720b4cf-042b-4419-8185-3b9f0147968e.png"> 
<img width="45%" style="max-width:45%" alt="Screen Shot 2021-11-02 at 9 40 22 am" src="https://user-images.githubusercontent.com/6542997/139751628-ae71ba57-ef1c-45aa-8d0d-97882dc45e11.png">
</p>

3rd option(with padding):
<p align="center">
<img width="45%" style="max-width:45%" alt="101757324-22e50900-3b2b-11eb-974b-4b4090a89c09" src="https://user-images.githubusercontent.com/6542997/139175453-c720b4cf-042b-4419-8185-3b9f0147968e.png"> 
<img width="45%" style="max-width:45%" alt="Screen Shot 2021-11-02 at 10 17 12 am" src="https://user-images.githubusercontent.com/6542997/139754400-d86c67a3-47d0-4882-903a-f1d0d0d14abd.png">

</p>