### PR TITLE
✨ NEW: Chapter numbers in equations

### DIFF
--- a/sphinx_jupyterbook_latex/events.py
+++ b/sphinx_jupyterbook_latex/events.py
@@ -29,6 +29,7 @@ def override_latex_config(app: Sphinx, config: Config) -> None:
     # only allow latex builder to access rest of the features
     config["latex_engine"] = "xelatex"
     config["latex_theme"] = "jupyterBook"
+    config["numfig"] = True
 
     latex_elements = cast(dict, config["latex_elements"])
 
@@ -81,6 +82,9 @@ def setup_latex_transforms(app: Sphinx) -> None:
         if sitemap is not None:
             if sitemap.file_format == "jb-book" and len(sitemap.root.subtrees) > 1:
                 app.config["latex_toplevel_sectioning"] = "part"
+                app.config[
+                    "numfig_secnum_depth"
+                ] = 2  # equation number with chapter numbers
                 app.env.jblatex_captions_to_parts = True
             elif sitemap.file_format == "jb-book":
                 app.config["latex_toplevel_sectioning"] = "chapter"

--- a/sphinx_jupyterbook_latex/events.py
+++ b/sphinx_jupyterbook_latex/events.py
@@ -74,6 +74,7 @@ def setup_latex_transforms(app: Sphinx) -> None:
     app.env.jblatex_captions_to_parts = False  # type: ignore[attr-defined]
     if app.config["jblatex_captions_to_parts"] is True:  # type: ignore[comparison-overlap]
         app.config["latex_toplevel_sectioning"] = "part"
+        app.config["numfig_secnum_depth"] = 2  # equation number with chapter numbers
         app.env.jblatex_captions_to_parts = True
     elif app.config["jblatex_captions_to_parts"] is None:
         # if using the sphinx-external-toc, we can look if parts are being specified


### PR DESCRIPTION
The equation did not show chapter numbers when `latex_toplevel_sectioning` was parts. As stated in this issue: https://github.com/executablebooks/sphinx-jupyterbook-latex/issues/48

The following PR fixes this issue.

fixes https://github.com/executablebooks/sphinx-jupyterbook-latex/issues/48