### PR TITLE
🐛  FIX: Passing down document options to sphinxmanual

### DIFF
--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -1,6 +1,10 @@
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{jupyterBook}[2020/11/06]
 
+% Pass document options to sphinxmanual.
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{sphinxmanual}}
+\ProcessOptions\relax
+
 \RequirePackage{xcolor}
 \RequirePackage[utf8]{inputenc}
 \RequirePackage{graphicx}

--- a/sphinx_jupyterbook_latex/theme/jupyterBook.cls
+++ b/sphinx_jupyterbook_latex/theme/jupyterBook.cls
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{jupyterBook}[2020/11/06]
 
-% Pass document options to sphinxmanual.
+% Pass document options defined in config to sphinxmanual.
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{sphinxmanual}}
 \ProcessOptions\relax
 


### PR DESCRIPTION
When passing extra options like `pointsize: 12pt` and `extraclassoptions: oneside` to the LaTeX generation using the latex_elements var in sphinx/config those had no effect in my experiments with jupyter-book although they can be found in the generated target LaTeX file.

In order to get the desired effect I had to repeat the option in jupyterBook.cls when loading the parent class https://github.com/florianbussmann/scientific-reports-with-jupyter/commit/513c685ad6f330e657534758071b433e5291cffe

I think the issue was that the provided document options for jupyterBook were not passed to sphinxmanual - at least the proposed change of passing all options down (https://github.com/florianbussmann/scientific-reports-with-jupyter/commit/0aa0bc649f3e5e3a8fc2431ba25d0eb2705c67aa) fixes this behavior for me so that I only need to define the options once. If instead this was a configuration error or misunderstanding on my side please let me know.



**Steps to reproduce:**
1. Checkout at https://github.com/florianbussmann/scientific-reports-with-jupyter/commit/513c685ad6f330e657534758071b433e5291cffe and generate PDF using 10pt (default)
```sh
$ git clone https://github.com/florianbussmann/scientific-reports-with-jupyter.git
$ cd scientific-reports-with-jupyter
$ git reset --hard 513c685ad6f330e657534758071b433e5291cffe
$ jupyter-book build . --builder pdflatex 
```
2. Add pointsize in `_config.yml` without additionally specifying it in `theme/jupyterBook.cls` 
```yaml
sphinx:
  config:
    latex_additional_files: ["theme/jupyterBook.cls"]
    latex_elements:
      extraclassoptions: oneside
      pointsize: 12pt
```
3. Look at the PDF from step 1. Now regenerate it with the command above and you will see no difference although book.tex states the specified pointsize `\documentclass[letterpaper,12pt,english,oneside]{jupyterBook}`