### PR TITLE
MAINT: bump upper sphinx version limit to 5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    sphinx>=3,<5
+    sphinx>=3,<5.1
     importlib-resources;python_version<'3.9'
 python_requires = >=3.6
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    sphinx>=3,<5.1
+    sphinx>=4,<5.1
     importlib-resources;python_version<'3.9'
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
Since `0.5.0` this package should be compatible with Sphinx 5, or more precisely with `sphinx<5.1` as because of #101.

As explained in https://github.com/conda-forge/sphinx-jupyterbook-latex-feedstock/pull/11#issue-1435774378 I'm using this successfully with Sphinx 5.0.1, but conda/mamba currently don't resolve such environments because `sphinx-jupyterbook-latex` still specifies `sphinx<5`.